### PR TITLE
fix: Meltano/asyncio LineOverrunError

### DIFF
--- a/src/tap_intacct/__init__.py
+++ b/src/tap_intacct/__init__.py
@@ -275,7 +275,7 @@ def do_discover(*, stdout: bool = True) -> Dict:
 
     if stdout:
         # Dump catalog to stdout
-        sys.stdout.write(json.dumps(catalog))
+        json.dump(catalog, sys.stdout, indent=4)
 
     return catalog
 


### PR DESCRIPTION
avoids error: Cannot start plugin tap-intacct: Separator is not found, and chunk exceed the limit

## Why are we changing this?

- fixes #4 

## What has changed?

- uses json.dump with indent to pretty print json and avoid any line length issues

## How to test it and expected results?

- `tap-intacct --discover` should print multiple lines to stdout
