### PR TITLE
add audit_history stream

### DIFF
--- a/src/tap_intacct/__init__.py
+++ b/src/tap_intacct/__init__.py
@@ -11,7 +11,7 @@ from singer import metadata
 
 from tap_intacct.exceptions import SageIntacctSDKError
 from tap_intacct.client import SageIntacctSDK, get_client
-from tap_intacct.const import DEFAULT_API_URL, KEY_PROPERTIES, REQUIRED_CONFIG_KEYS, INTACCT_OBJECTS, IGNORE_FIELDS
+from tap_intacct.const import DEFAULT_API_URL, KEY_PROPERTIES, REQUIRED_CONFIG_KEYS, INTACCT_OBJECTS, IGNORE_FIELDS, REP_KEYS, GET_BY_DATE_FIELD
 
 logger = singer.get_logger()
 
@@ -267,7 +267,8 @@ def sync_stream(stream: str) -> None:
     )
 
     for intacct_object in data:
-        row_timestamp = singer.utils.strptime_to_utc(intacct_object['WHENMODIFIED'])
+        rep_key = REP_KEYS.get(stream, GET_BY_DATE_FIELD)
+        row_timestamp = singer.utils.strptime_to_utc(intacct_object[rep_key])
         if row_timestamp > bookmark:
             bookmark = row_timestamp
 

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -23,7 +23,7 @@ from tap_intacct.exceptions import (
     WrongParamsError,
 )
 
-from .const import GET_BY_DATE_FIELD, INTACCT_OBJECTS
+from .const import GET_BY_DATE_FIELD, INTACCT_OBJECTS, KEY_PROPERTIES, REP_KEYS
 
 logger = singer.get_logger()
 
@@ -282,13 +282,15 @@ class SageIntacctSDK:
         """
         intacct_object_type = INTACCT_OBJECTS[object_type]
         total_intacct_objects = []
+        pk = KEY_PROPERTIES[object_type][0]
+        rep_key = REP_KEYS.get(object_type, GET_BY_DATE_FIELD)
         get_count = {
             'query': {
                 'object': intacct_object_type,
-                'select': {'field': 'RECORDNO'},
+                'select': {'field': pk},
                 'filter': {
                     'greaterthanorequalto': {
-                        'field': GET_BY_DATE_FIELD,
+                        'field': rep_key,
                         'value': _format_date_for_intacct(from_date),
                     }
                 },
@@ -296,7 +298,6 @@ class SageIntacctSDK:
                 'options': {'showprivate': 'true'},
             }
         }
-
         response = self.format_and_send_request(get_count)
         count = int(response['data']['@totalcount'])
         pagesize = 1000
@@ -309,7 +310,7 @@ class SageIntacctSDK:
                     'options': {'showprivate': 'true'},
                     'filter': {
                         'greaterthanorequalto': {
-                            'field': GET_BY_DATE_FIELD,
+                            'field': rep_key,
                             'value': _format_date_for_intacct(from_date),
                         }
                     },

--- a/src/tap_intacct/const.py
+++ b/src/tap_intacct/const.py
@@ -28,7 +28,8 @@ KEY_PROPERTIES = {
     'items': ["RECORDNO"],
     'invoice_items': ["RECORDNO"],
     'adjustment_items': ["RECORDNO"],
-    'departments': ["DEPARTMENTID"]
+    'departments': ["DEPARTMENTID"],
+    "audit_history": ["ID"]
 }
 
 # List of available objects with their internal object-reference/endpoint name.
@@ -54,7 +55,12 @@ INTACCT_OBJECTS = {
     "items": "ITEM",
     "invoice_items": "ARINVOICEITEM",
     "adjustment_items": "ARADJUSTMENTITEM",
-    "departments": "DEPARTMENT"
+    "departments": "DEPARTMENT",
+    "audit_history": "AUDITHISTORY"
+}
+
+REP_KEYS = {
+    "audit_history" : "ACCESSTIME"
 }
 
 IGNORE_FIELDS =["PASSWORD"]


### PR DESCRIPTION
## Why are we changing this?

Adding audit_history stream to get deleted records. Adapt existing logic in `get_by_date` for different primary keys and rep keys.

## What has changed?

get_by_date function and costs
