### PR TITLE
comment rest 1 hour from rep_key date, add 1 sec

### DIFF
--- a/src/tap_intacct/__init__.py
+++ b/src/tap_intacct/__init__.py
@@ -88,10 +88,13 @@ def _get_abs_path(path: str) -> Path:
 
 def _get_start(key: str) -> dt.datetime:
     if key in Context.state:
-        # Subtract look-back from Config (default 1 hour) from State, in case of late arriving records.
-        start = singer.utils.strptime_to_utc(Context.state[key]) - dt.timedelta(
-            hours=Context.config['event_lookback']
-        )
+        start = singer.utils.strptime_to_utc(Context.state[key])
+
+        # commenting logic below due to HGI-5749 
+        # # Subtract look-back from Config (default 1 hour) from State, in case of late arriving records.
+        # start = start - dt.timedelta(
+        #     hours=Context.config['event_lookback']
+        # )
     else:
         start = singer.utils.strptime_to_utc(Context.config['start_date'])
 

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -295,6 +295,10 @@ class SageIntacctSDK:
         total_intacct_objects = []
         pk = KEY_PROPERTIES[object_type][0]
         rep_key = REP_KEYS.get(object_type, GET_BY_DATE_FIELD)
+
+        # add 1 second to date
+        from_date = from_date + dt.timedelta(seconds=1)
+
         get_count = {
             'query': {
                 'object': intacct_object_type,


### PR DESCRIPTION
## Why are we changing this?

- Same records are coming in consecutive jobs due to the logic where we rest 1 hour to the rep_key

## What has changed?

- Comment logic to  rest 1 hour to the rep_key, and add 1 second to the rep_key to not fetch same records