### PR TITLE
fix position of adding one second to rep_key

### DIFF
--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -303,6 +303,7 @@ class SageIntacctSDK:
         rep_key = REP_KEYS.get(object_type, GET_BY_DATE_FIELD)
 
 
+        from_date = from_date + dt.timedelta(seconds=1)
         # if it's an audit_history stream filter only created (C) and deleted (D) records
         if object_type == "audit_history":
             filter = {
@@ -328,9 +329,6 @@ class SageIntacctSDK:
                     'value': _format_date_for_intacct(from_date),
                 }
             }
-
-        # add 1 second to date
-        from_date = from_date + dt.timedelta(seconds=1)
 
         get_count = {
             'query': {


### PR DESCRIPTION
## Why are we changing this?

Rep key was not working properly, it would always fetch the data since the date in the state instead of fetching data from after the date in the state.

## What has changed?

There was already logic in place to add 1 second to the state to avoid this issue but it was in the wrong place. Move this logic to the right place,

