### PR TITLE
add support to fetch data iterating by dae

### DIFF
--- a/src/tap_intacct/__init__.py
+++ b/src/tap_intacct/__init__.py
@@ -240,6 +240,7 @@ def sync_stream(stream: str) -> None:
     logger.info('Syncing %s data from %s to %s', stream, from_datetime, time_extracted)
     bookmark = from_datetime
     fields = Context.get_selected_fields(stream)
+    iterate_by_date = Context.config.get("iterate_by_date") or False
 
     try:
         # Attempt to get data with all fields
@@ -247,6 +248,7 @@ def sync_stream(stream: str) -> None:
             object_type=stream,
             fields=fields,
             from_date=from_datetime,
+            iterate_by_date=iterate_by_date
         )
 
         # Test getting a record
@@ -269,12 +271,13 @@ def sync_stream(stream: str) -> None:
             if field in fields:
                 fields.remove(field)
 
-    # Make the request with the final fields
-    data = Context.intacct_client.get_by_date(
-        object_type=stream,
-        fields=fields,
-        from_date=from_datetime,
-    )
+        # Make the request with the final fields
+        data = Context.intacct_client.get_by_date(
+            object_type=stream,
+            fields=fields,
+            from_date=from_datetime,
+            iterate_by_date=iterate_by_date
+        )
 
     for intacct_object in data:
         if stream.startswith("audit_history"):

--- a/src/tap_intacct/__init__.py
+++ b/src/tap_intacct/__init__.py
@@ -241,7 +241,7 @@ def sync_stream(stream: str) -> None:
     bookmark = from_datetime
     fields = Context.get_selected_fields(stream)
     iterate_by_date = Context.config.get("iterate_by_date") or False
-    days = Context.config.get("days_period")
+    days = Context.config.get("days_period") or 5 # default to 5 is days_period is not in config or is empty
 
     try:
         # Attempt to get data with all fields

--- a/src/tap_intacct/__init__.py
+++ b/src/tap_intacct/__init__.py
@@ -241,6 +241,7 @@ def sync_stream(stream: str) -> None:
     bookmark = from_datetime
     fields = Context.get_selected_fields(stream)
     iterate_by_date = Context.config.get("iterate_by_date") or False
+    days = Context.config.get("days_period")
 
     try:
         # Attempt to get data with all fields
@@ -248,7 +249,8 @@ def sync_stream(stream: str) -> None:
             object_type=stream,
             fields=fields,
             from_date=from_datetime,
-            iterate_by_date=iterate_by_date
+            iterate_by_date=iterate_by_date,
+            days=days
         )
 
         # Test getting a record
@@ -276,7 +278,8 @@ def sync_stream(stream: str) -> None:
             object_type=stream,
             fields=fields,
             from_date=from_datetime,
-            iterate_by_date=iterate_by_date
+            iterate_by_date=iterate_by_date,
+            days=days
         )
 
     for intacct_object in data:

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -341,7 +341,7 @@ class SageIntacctSDK:
             offset = offset + pagesize
 
     def get_by_date(
-        self, *, object_type: str, fields: List[str], from_date: dt.datetime, iterate_by_date=False, days=30
+        self, *, object_type: str, fields: List[str], from_date: dt.datetime, iterate_by_date=False, days
     ) -> List[Dict]:
         """
         Get multiple objects of a single type from Sage Intacct, filtered by GET_BY_DATE_FIELD (WHENMODIFIED) date.
@@ -419,8 +419,8 @@ class SageIntacctSDK:
                 start_date = from_date
 
             while start_date <= today:
-                #TODO remove days '5' used for testing, and use config days (dynamic)
-                end_date = start_date + dt.timedelta(days=5)
+
+                end_date = start_date + dt.timedelta(days=days)
                 logger.info('Syncing %s data from %s to %s', object_type, start_date, end_date)
 
                 if object_type == "audit_history":

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -390,13 +390,16 @@ class SageIntacctSDK:
                     'orderby':{'order': [{'field':rep_key, 'ascending': 'true'}]}
                 }
             }
-            oldest_date = self.format_and_send_request(get_oldest_date)
-            oldest_date = oldest_date["data"].get(intacct_object_type, {}).get(rep_key)
-            if oldest_date:
-                start_date = dt.datetime.strptime(oldest_date, '%m/%d/%Y %H:%M:%S') - dt.timedelta(seconds=1)
-                start_date = start_date.replace(tzinfo=dt.timezone.utc)
-            else:
-                return []
+            try:
+                # try to get the oldest_date to avoid unneccesary iterations
+                oldest_date = self.format_and_send_request(get_oldest_date)
+                oldest_date = oldest_date["data"].get(intacct_object_type, {}).get(rep_key)
+                if oldest_date:
+                    start_date = dt.datetime.strptime(oldest_date, '%m/%d/%Y %H:%M:%S') - dt.timedelta(seconds=1)
+                    start_date = start_date.replace(tzinfo=dt.timezone.utc)
+            except:
+                # if it fails due to not enough resources -> use from_date
+                start_date = from_date
 
             while start_date <= today:
                 end_date = start_date + dt.timedelta(days=30)

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -128,7 +128,7 @@ class SageIntacctSDK:
 
     @backoff.on_exception(
         backoff.expo,
-        (BadGatewayError),
+        (BadGatewayError, ConnectionError, ConnectionResetError, requests.exceptions.ConnectionError),
         max_tries=5,
         factor=3,
     )

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -138,6 +138,8 @@ class SageIntacctSDK:
         logger.info(f"request to {api_url} with body {body}")
         response = requests.post(api_url, headers=api_headers, data=body)
 
+        logger.info(f"request to {api_url} response {response.text}, statuscode {response.status_code}")
+
         parsed_xml = xmltodict.parse(response.text)
         parsed_response = json.loads(json.dumps(parsed_xml))
 

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -419,8 +419,8 @@ class SageIntacctSDK:
                 start_date = from_date
 
             while start_date <= today:
-                #TODO remove days '15' used for testing, and use days (dynamic)
-                end_date = start_date + dt.timedelta(days=15)
+                #TODO remove days '5' used for testing, and use config days (dynamic)
+                end_date = start_date + dt.timedelta(days=5)
                 logger.info('Syncing %s data from %s to %s', object_type, start_date, end_date)
 
                 if object_type == "audit_history":

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -27,6 +27,9 @@ from .const import GET_BY_DATE_FIELD, INTACCT_OBJECTS, KEY_PROPERTIES, REP_KEYS
 
 logger = singer.get_logger()
 
+class InvalidXmlResponse(Exception):
+    pass
+
 def _format_date_for_intacct(datetime: dt.datetime) -> str:
     """
     Intacct expects datetimes in a 'MM/DD/YY HH:MM:SS' string format.
@@ -140,8 +143,11 @@ class SageIntacctSDK:
 
         logger.info(f"request to {api_url} response {response.text}, statuscode {response.status_code}")
 
-        parsed_xml = xmltodict.parse(response.text)
-        parsed_response = json.loads(json.dumps(parsed_xml))
+        try:
+            parsed_xml = xmltodict.parse(response.text)
+            parsed_response = json.loads(json.dumps(parsed_xml))
+        except:
+            raise InvalidXmlResponse(f"Response status code: {response.status_code}, response: {response.text}")
 
         if response.status_code == 200:
             if parsed_response['response']['control']['status'] == 'success':

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -135,6 +135,7 @@ class SageIntacctSDK:
         api_headers = {'content-type': 'application/xml'}
         api_headers.update(self.__headers)
         body = xmltodict.unparse(dict_body)
+        logger.info(f"request to {api_url} with body {body}")
         response = requests.post(api_url, headers=api_headers, data=body)
 
         parsed_xml = xmltodict.parse(response.text)

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -330,7 +330,7 @@ class SageIntacctSDK:
             offset = offset + pagesize
 
     def get_by_date(
-        self, *, object_type: str, fields: List[str], from_date: dt.datetime, iterate_by_date=False
+        self, *, object_type: str, fields: List[str], from_date: dt.datetime, iterate_by_date=False, days=30
     ) -> List[Dict]:
         """
         Get multiple objects of a single type from Sage Intacct, filtered by GET_BY_DATE_FIELD (WHENMODIFIED) date.
@@ -408,7 +408,7 @@ class SageIntacctSDK:
                 start_date = from_date
 
             while start_date <= today:
-                end_date = start_date + dt.timedelta(days=30)
+                end_date = start_date + dt.timedelta(days=days)
                 logger.info('Syncing %s data from %s to %s', object_type, start_date, end_date)
 
                 if object_type == "audit_history":

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -408,7 +408,8 @@ class SageIntacctSDK:
                 start_date = from_date
 
             while start_date <= today:
-                end_date = start_date + dt.timedelta(days=days)
+                #TODO remove days '15' used for testing, and use days (dynamic)
+                end_date = start_date + dt.timedelta(days=15)
                 logger.info('Syncing %s data from %s to %s', object_type, start_date, end_date)
 
                 if object_type == "audit_history":


### PR DESCRIPTION
## Why are we changing this?

- the MR adds support to fetch data iterating by date (monthly) because streams with too much data fail on memory issues.

## What has changed?

- optional way to fetch data iterating by date using a flag in config "iterate_by_date"

## How to test it and expected results?

- fetch any stream with config flag "iterate_by_date"=true, should fetch the same amount of records as the default original logic "iterate_by_date"=false.
